### PR TITLE
Client basic auth support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY files/root /etc/crontabs/root
 
 COPY files/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY files/ssl.conf /usr/local/openresty/nginx/conf/ssl.conf
+COPY files/client_auth.conf /usr/local/openresty/nginx/conf/client_auth.conf
 
 ENV PORT 5000
 RUN chmod a+x /startup.sh /renew_token.sh

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The proxy is packaged in a docker container and can be configured with following
 | `ENABLE_SSL`                        | Used to enable SSL/TLS for proxy               | Optional                          | `false`    |
 | `REGISTRY_HTTP_TLS_KEY`             | Path to TLS key in the container               | Required with TLS                 |            |
 | `REGISTRY_HTTP_TLS_CERTIFICATE`     | Path to TLS cert in the container              | Required with TLS                 |            |
+| `CLIENT_AUTH_USER_FILE`             | Path to auth_basic user file in the container for client authentication | Optional |            |
 
 ### Example:
 

--- a/files/client_auth.conf
+++ b/files/client_auth.conf
@@ -1,0 +1,3 @@
+# Client auth configuration
+auth_basic basic;
+auth_basic_user_file CLIENT_AUTH_USER_FILE;

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -30,6 +30,7 @@ http {
     listen PORT SSL_LISTEN default_server;
 
     SSL_INCLUDE
+    AUTH_INCLUDE
 
     # Cache
     add_header X-Cache-Status   $upstream_cache_status;
@@ -98,6 +99,9 @@ http {
     # query params. Also the params should be part of cache key for nginx to
     # issue HIT for same image blob.
     location @handle_redirect {
+      # Clear Authorization header from the client, if present
+      proxy_set_header Authorization "";
+
       set                    $saved_redirect_location '$upstream_http_location';
       proxy_pass             $saved_redirect_location;
       proxy_cache            cache;

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -42,6 +42,7 @@ echo Using cache key $CACHE_KEY
 SCHEME=http
 CONFIG=/usr/local/openresty/nginx/conf/nginx.conf
 SSL_CONFIG=/usr/local/openresty/nginx/conf/ssl.conf
+AUTH_CONFIG=/usr/local/openresty/nginx/conf/client_auth.conf
 
 if [ "$ENABLE_SSL" ]; then
   sed -i -e s!REGISTRY_HTTP_TLS_CERTIFICATE!"$REGISTRY_HTTP_TLS_CERTIFICATE"!g $SSL_CONFIG
@@ -49,6 +50,11 @@ if [ "$ENABLE_SSL" ]; then
   SSL_LISTEN="ssl"
   SSL_INCLUDE="include $SSL_CONFIG;"
   SCHEME="https"
+fi
+
+if [ "$CLIENT_AUTH_USER_FILE" ]; then
+    sed -i -e s!CLIENT_AUTH_USER_FILE!"$CLIENT_AUTH_USER_FILE"!g $AUTH_CONFIG
+    AUTH_INCLUDE="include $AUTH_CONFIG;"
 fi
 
 # Update nginx config
@@ -60,6 +66,7 @@ sed -i -e s!CACHE_KEY!"$CACHE_KEY"!g $CONFIG
 sed -i -e s!SCHEME!"$SCHEME"!g $CONFIG
 sed -i -e s!SSL_INCLUDE!"$SSL_INCLUDE"!g $CONFIG
 sed -i -e s!SSL_LISTEN!"$SSL_LISTEN"!g $CONFIG
+sed -i -e s!AUTH_INCLUDE!"$AUTH_INCLUDE"!g $CONFIG
 
 # Update health-check
 sed -i -e s!PORT!"$PORT"!g /health-check.sh


### PR DESCRIPTION
This PR adds client auth support via simple HTTP basic auth.  The flow here is:

- The admin creates a htpasswd file using normal tools, and volume mounts that into the container
- The `CLIENT_AUTH_USER_FILE` ENV var is set to the htpasswd file path in the container
- The presence of the `CLIENT_AUTH_USER_FILE` variable enables the client_auth.conf file in the nginx config, which configures basic auth via ngx_http_auth_basic_module.

To pull from the registry clients must now auth with `docker login` using credentials from the htpasswd file.  Unauthenticated clients will get a error.

When `CLIENT_AUTH_USER_FILE` is unset (the default) application behavior is unchanged.

This feature is useful in environments where having an open proxy that can pull from ECR is undesirable for security reasons.