### PR TITLE
update to aws-cli v2 to use eks iam serviceaccount oidc roles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,37 @@ FROM openresty/openresty:1.19.9.1-12-alpine
 
 USER root
 
-RUN apk add -v --no-cache bind-tools python3 py-pip py3-urllib3 py3-colorama supervisor \
- && mkdir /cache \
- && addgroup -g 110 nginx \
- && adduser -u 110  -D -S -h /cache -s /sbin/nologin -G nginx nginx \
- && pip install --upgrade pip awscli==1.11.183 \
- && apk -v --purge del py-pip
+ENV GLIBC_VER=2.31-r0
+
+# install glibc compatibility for alpine
+RUN apk --no-cache add \
+        binutils curl \
+        bind-tools python3 supervisor \
+        py3-urllib3 py3-colorama \
+    && mkdir /cache \
+    && addgroup -g 110 nginx \
+    && adduser -u 110  -D -S -h /cache -s /sbin/nologin -G nginx nginx \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    && apk --no-cache del \
+        binutils \
+        curl \
+    && rm glibc-${GLIBC_VER}.apk \
+    && rm glibc-bin-${GLIBC_VER}.apk \
+    && rm -rf /var/cache/apk/*
 
 COPY files/startup.sh files/renew_token.sh files/health-check.sh  /
 COPY files/ecr.ini /etc/supervisor.d/ecr.ini

--- a/files/renew_token.sh
+++ b/files/renew_token.sh
@@ -8,7 +8,7 @@ AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
 
 # retry till new get new token
 while true; do
-  TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
+  TOKEN=$(aws ecr get-login-password)
   [ ! -z "${TOKEN}" ] && break
   echo "Warn: Unable to get new token, wait and retry!"
   sleep 30

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -79,7 +79,7 @@ chmod 600 -R ${AWS_FOLDER}
 
 # add the auth token in default.conf
 AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
-TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
+TOKEN=$(aws ecr get-login-password)
 AUTH_N=$(echo AWS:${TOKEN}  | base64 |tr -d "[:space:]")
 sed -i "s|${AUTH%??}|${AUTH_N}|g" $CONFIG
 


### PR DESCRIPTION
Switches to v2 of awscli to properly support IAM roles assumed by a kubernetes service account (a web identity token assumed by an OIDC connector). V1 of the awscli does not support web identity tokens or the `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable, leading to the cli using the EKS node role instead of the role provided by the service account. V2 also provides `ecr get-login-password`, which replaces `ecr get-login --no-include-email | awk '{print $6}'`.

No native alpine or pip support/packages are provided for the awscli, so the package must be downloaded directly from AWS, and installed alongside with the appropriate c libraries to ensure proper function. 