### PR TITLE
Add configurable cache invalidation + support behind SSL proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The proxy is packaged in a docker container and can be configured with following
 | `PORT`                              | Port on which proxy listens                    | Required                          |            |
 | `CACHE_MAX_SIZE`                    | Maximum size for cache volume                  | Optional                          |  `75g`     |
 | `CACHE_KEY`                         | Cache key used for the content by nginx        | Optional                          |  `$uri`    |
+| `CACHE_INACTIVE_TIME`               | Cache inactive time used by nginx              | Optional                          |   `1y`     |
 | `ENABLE_SSL`                        | Used to enable SSL/TLS for proxy               | Optional                          | `false`    |
 | `BEHIND_SSL_PROXY`                  | Fixes redirects when behind a proxy handling SSL (i.e. aws ALB)          | Optional                          | `false`    |
 | `REGISTRY_HTTP_TLS_KEY`             | Path to TLS key in the container               | Required with TLS                 |            |
@@ -43,6 +44,7 @@ docker run -d --name docker-registry-proxy --net=host \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
   -e AWS_REGION=${AWS_DEFAULT_REGION} \
   -e CACHE_MAX_SIZE=100g \
+  -e CACHE_INACTIVE_TIME=1y \
   -e ENABLE_SSL=true \
   -e REGISTRY_HTTP_TLS_KEY=/opt/ssl/key.pem \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/opt/ssl/certificate.pem \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The proxy is packaged in a docker container and can be configured with following
 | `CACHE_MAX_SIZE`                    | Maximum size for cache volume                  | Optional                          |  `75g`     |
 | `CACHE_KEY`                         | Cache key used for the content by nginx        | Optional                          |  `$uri`    |
 | `ENABLE_SSL`                        | Used to enable SSL/TLS for proxy               | Optional                          | `false`    |
+| `BEHIND_SSL_PROXY`                  | Fixes redirects when behind a proxy handling SSL (i.e. aws ALB)          | Optional                          | `false`    |
 | `REGISTRY_HTTP_TLS_KEY`             | Path to TLS key in the container               | Required with TLS                 |            |
 | `REGISTRY_HTTP_TLS_CERTIFICATE`     | Path to TLS cert in the container              | Required with TLS                 |            |
 
@@ -75,3 +76,4 @@ See the [values-file](https://github.com/evryfs/helm-charts/blob/master/charts/e
 The proxy is using `HTTP` (plain text) as default protocol for now. So in order to avoid docker client complaining either:
  - (**Recommended**) Enable SSL/TLS using `ENABLE_SSL` configuration. For that you will have to mount your **valid** certificate/key in the container and pass the paths using  `REGISTRY_HTTP_TLS_*` variables.
  - Mark the registry host as insecure in your client [deamon config](https://docs.docker.com/registry/insecure/).
+ - If proxy is sitting behind an AWS ALB that handles SSL termination/redirect for clients (like running this proxy in an EKS cluster), setting `BEHIND_SSL_PROXY` to true will ensure `docker push` compatibility by setting `proxy_redirect` settings to https defaults (scheme: https, port: 443) irrespective of `PORT` variable.

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -12,7 +12,7 @@ http {
   keepalive_timeout 65;
   sendfile on;
 
-  proxy_cache_path /cache/cache levels=1:2 keys_zone=cache:16m inactive=1y max_size=CACHE_MAX_SIZE use_temp_path=off;
+  proxy_cache_path /cache/cache levels=1:2 keys_zone=cache:16m inactive=CACHE_INACTIVE_TIME max_size=CACHE_MAX_SIZE use_temp_path=off;
   resolver RESOLVER valid=30s;
 
   # this is necessary for us to be able to disable request buffering in all cases

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -62,7 +62,7 @@ http {
     location / {
       set $url        UPSTREAM;
       proxy_pass      $url;
-      proxy_redirect  $url SCHEME://$host:PORT;
+      proxy_redirect  $url SCHEME://$host:REDIRECT_PORT;
 
       # Add AWS ECR authentication headers
       proxy_set_header  X-Real-IP          $remote_addr;
@@ -78,7 +78,7 @@ http {
     location ~ ^/v2/.*/blobs/[a-z0-9]+:[a-f0-9]+$ {
       set $url        UPSTREAM;
       proxy_pass      $url;
-      proxy_redirect  $url SCHEME://$host:PORT;
+      proxy_redirect  $url SCHEME://$host:REDIRECT_PORT;
 
       # Add AWS ECR authentication headers
       proxy_set_header  X-Real-IP          $remote_addr;

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -40,6 +40,7 @@ CACHE_KEY=${CACHE_KEY:='$uri'}
 echo Using cache key $CACHE_KEY
 
 SCHEME=http
+REDIRECT_PORT=$PORT
 CONFIG=/usr/local/openresty/nginx/conf/nginx.conf
 SSL_CONFIG=/usr/local/openresty/nginx/conf/ssl.conf
 
@@ -49,10 +50,14 @@ if [ "$ENABLE_SSL" ]; then
   SSL_LISTEN="ssl"
   SSL_INCLUDE="include $SSL_CONFIG;"
   SCHEME="https"
+elif [ "$BEHIND_SSL_PROXY" ]; then
+  SCHEME="https"
+  REDIRECT_PORT="443"
 fi
 
 # Update nginx config
 sed -i -e s!UPSTREAM!"$UPSTREAM"!g $CONFIG
+sed -i -e s!REDIRECT_PORT!"$REDIRECT_PORT"!g $CONFIG
 sed -i -e s!PORT!"$PORT"!g $CONFIG
 sed -i -e s!RESOLVER!"$RESOLVER"!g $CONFIG
 sed -i -e s!CACHE_MAX_SIZE!"$CACHE_MAX_SIZE"!g $CONFIG

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -39,6 +39,9 @@ echo Using cache max size $CACHE_MAX_SIZE
 CACHE_KEY=${CACHE_KEY:='$uri'}
 echo Using cache key $CACHE_KEY
 
+CACHE_INACTIVE_TIME=${CACHE_INACTIVE_TIME=:-1y}
+echo Using cache max size $CACHE_MAX_SIZE
+
 SCHEME=http
 REDIRECT_PORT=$PORT
 CONFIG=/usr/local/openresty/nginx/conf/nginx.conf
@@ -62,6 +65,7 @@ sed -i -e s!PORT!"$PORT"!g $CONFIG
 sed -i -e s!RESOLVER!"$RESOLVER"!g $CONFIG
 sed -i -e s!CACHE_MAX_SIZE!"$CACHE_MAX_SIZE"!g $CONFIG
 sed -i -e s!CACHE_KEY!"$CACHE_KEY"!g $CONFIG
+sed -i -e s!CACHE_INACTIVE_TIME!"$CACHE_INACTIVE_TIME"!g $CONFIG
 sed -i -e s!SCHEME!"$SCHEME"!g $CONFIG
 sed -i -e s!SSL_INCLUDE!"$SSL_INCLUDE"!g $CONFIG
 sed -i -e s!SSL_LISTEN!"$SSL_LISTEN"!g $CONFIG


### PR DESCRIPTION
Adds two new configuration options via env vars. 

- `BEHIND_SSL_PROXY` for running in EKS environments where SSL/TLS termination is managed by the ALB being used for Ingress. Even if nginx isn't handling certificate termination directly, `SCHEME` must be set to `https` or pushing via this registry proxy will fail while attempting to upload chunks. Default: `false`
- `CACHE_INACTIVE_TIMER` sets a configurable cache timeout instead of a static 1 year. Default: `1y`